### PR TITLE
Update for v6.1.10_rel-rx-1.0.0 final

### DIFF
--- a/configuration/azure-rtos.xml
+++ b/configuration/azure-rtos.xml
@@ -812,10 +812,16 @@
 					<file>configuration/samples/iot_sdk/README.md</file>
 					<path>.</path>
 				</impdir>
-				<!-- copy readme and pdf for RSK RX671-->
+				<!-- copy readme for RSK RX671 and RX72N Envision Kit -->
 				<impdir>
 					<board>RSKRX671</board>
 					<file>configuration/samples/iot_sdk/rsk-rx671/README.md</file>
+					<path>.</path>
+				</impdir>
+				<impdir>
+					<board>RX72NEnvisionKit</board>
+					<board>EnvisionKitRX72N</board>
+					<file>configuration/samples/iot_sdk/rx72n-envision-kit/README.md</file>
 					<path>.</path>
 				</impdir>
 				<!-- copy driver codes -->
@@ -1118,10 +1124,16 @@
 					<file>configuration/samples/iot_sdk/README.md</file>
 					<path>.</path>
 				</impdir>
-				<!-- copy readme and pdf for RSK RX671-->
+				<!-- copy readme for RSK RX671 and RX72N Envision Kit -->
 				<impdir>
 					<board>RSKRX671</board>
 					<file>configuration/samples/iot_sdk/rsk-rx671/README.md</file>
+					<path>.</path>
+				</impdir>
+				<impdir>
+					<board>RX72NEnvisionKit</board>
+					<board>EnvisionKitRX72N</board>
+					<file>configuration/samples/iot_sdk/rx72n-envision-kit/README.md</file>
 					<path>.</path>
 				</impdir>
 				<!-- copy driver codes -->
@@ -1424,10 +1436,16 @@
 					<file>configuration/samples/iot_sdk/README.md</file>
 					<path>.</path>
 				</impdir>
-				<!-- copy readme and pdf for RSK RX671-->
+				<!-- copy readme for RSK RX671 and RX72N Envision Kit -->
 				<impdir>
 					<board>RSKRX671</board>
 					<file>configuration/samples/iot_sdk/rsk-rx671/README.md</file>
+					<path>.</path>
+				</impdir>
+				<impdir>
+					<board>RX72NEnvisionKit</board>
+					<board>EnvisionKitRX72N</board>
+					<file>configuration/samples/iot_sdk/rx72n-envision-kit/README.md</file>
 					<path>.</path>
 				</impdir>
 				<!-- copy driver codes -->
@@ -1706,6 +1724,10 @@
 					<folder>configuration/samples/guix_8bpp/rx72n-envision-kit/src</folder>
 					<path>src</path>
 				</impdir>
+				<impdir>
+					<file>configuration/samples/guix_8bpp/README.md</file>
+					<path>.</path>
+				</impdir>
 				<!-- copy driver codes -->
 				<impdir>
 					<folder>rx-driver-package/source/r_cmt_rx/r_cmt_rx_vx.xx/r_cmt_rx</folder>
@@ -1852,6 +1874,12 @@
 				</impdir>
 				<impdir>
 					<file>configuration/samples/guix_16bpp/README.md</file>
+					<path>.</path>
+				</impdir>
+				<impdir>
+					<board>RX72NEnvisionKit</board>
+					<board>EnvisionKitRX72N</board>
+					<file>configuration/samples/guix_16bpp/rx72n-envision-kit/README.md</file>
 					<path>.</path>
 				</impdir>
 				<!-- copy driver codes -->
@@ -2017,7 +2045,13 @@
 					<path>src</path>
 				</impdir>
 				<impdir>
-					<file>configuration/samples/guix_16bpp_draw2d/README.md</file>
+					<file>configuration/samples/guix_16bpp/README.md</file>
+					<path>.</path>
+				</impdir>
+				<impdir>
+					<board>RX72NEnvisionKit</board>
+					<board>EnvisionKitRX72N</board>
+					<file>configuration/samples/guix_16bpp/rx72n-envision-kit/README.md</file>
 					<path>.</path>
 				</impdir>
 				<!-- copy driver codes -->

--- a/configuration/samples/guix_16bpp/rx72n-envision-kit/README.md
+++ b/configuration/samples/guix_16bpp/rx72n-envision-kit/README.md
@@ -17,7 +17,17 @@ https://docs.microsoft.com/azure/rtos/guix/about-guix
 ------------------------
 2. Caution / Known Issue
 ------------------------
-If you are using project with GCC RX compiler, please take note on following issue.
+2.1. The device on RX72N Envision Kit is R5F572NN (Flash memory 4MB).
+However, when creating new project with old board version (v1.11 and older),
+the project is created with R5F572ND device (Flash memory 2MB).
+You can go to [Board] tab of Smart Configurator editor to check the correctness of the device.
+In case the device is R5F572ND, at Board tab, you can click [...] button behind the Board combo-box
+to quickly go to Change Device dialog and change target device to R5F572NN.
+
+This issue will be fixed at newer version of board.
+
+
+2.2. If you are using project with GCC RX compiler, please take note on following issue.
 
 For this GUIX 16bpp sample project, RAM2 should be used for sections in src/linker_script.ld
 However, the section setting is changed to RAM in linker_script.ld when first build and after code generated.

--- a/configuration/samples/guix_8bpp/README.md
+++ b/configuration/samples/guix_8bpp/README.md
@@ -1,0 +1,14 @@
+---------------
+1. Usage Notes
+---------------
+To configure/change the current graphical display on LCD, please use Azure RTOS GUIX Studio
+(The Azure RTOS GUIX Studio installer is available here: https://aka.ms/azrtos-guix-installer)
+- Open Azure RTOS GUIX Studio
+- Select "Open Project"
+- Select .gxp file that is available under "src" folder of this project
+
+For more information about how to use Azure RTOS GUIX Studio, please check this page
+https://docs.microsoft.com/azure/rtos/guix/about-guix-studio
+
+For more information about GUIX in general, please refer to the following page
+https://docs.microsoft.com/azure/rtos/guix/about-guix

--- a/configuration/samples/iot_sdk/rsk-rx671/src/main.c
+++ b/configuration/samples/iot_sdk/rsk-rx671/src/main.c
@@ -68,7 +68,8 @@ extern VOID sample_entry(NX_IP* ip_ptr, NX_PACKET_POOL* pool_ptr, NX_DNS* dns_pt
 
 #ifndef SAMPLE_TIME_SERVER_NAME
 //#define SAMPLE_TIME_SERVER_NAME     "utcnist.colorado.edu"    /* Time Server.  */
-#define SAMPLE_TIME_SERVER_NAME       "time4.nrc.ca"
+//#define SAMPLE_TIME_SERVER_NAME     "time4.nrc.ca"
+#define SAMPLE_TIME_SERVER_NAME       "0.pool.ntp.org"
 #endif /* SAMPLE_TIME_SERVER_NAME */
 
 /* Default time. GMT: Saturday, January 1, 2022 12:00:00 AM. Epoch timestamp: 1640995200.  */

--- a/configuration/samples/iot_sdk/rx65n-cloudkit/src/main.c
+++ b/configuration/samples/iot_sdk/rx65n-cloudkit/src/main.c
@@ -68,7 +68,8 @@ extern VOID sample_entry(NX_IP* ip_ptr, NX_PACKET_POOL* pool_ptr, NX_DNS* dns_pt
 
 #ifndef SAMPLE_TIME_SERVER_NAME
 //#define SAMPLE_TIME_SERVER_NAME     "utcnist.colorado.edu"    /* Time Server.  */
-#define SAMPLE_TIME_SERVER_NAME       "time4.nrc.ca"
+//#define SAMPLE_TIME_SERVER_NAME     "time4.nrc.ca"
+#define SAMPLE_TIME_SERVER_NAME       "0.pool.ntp.org"
 #endif /* SAMPLE_TIME_SERVER_NAME */
 
 /* Default time. GMT: Saturday, January 1, 2022 12:00:00 AM. Epoch timestamp: 1640995200.  */

--- a/configuration/samples/iot_sdk/rx72n-envision-kit/README.md
+++ b/configuration/samples/iot_sdk/rx72n-envision-kit/README.md
@@ -1,0 +1,17 @@
+------------------------
+1. Caution / Known Issue
+------------------------
+The device on RX72N Envision Kit is R5F572NN (Flash memory 4MB).
+However, when creating new project with old board version (v1.11 and older),
+the project is created with R5F572ND device (Flash memory 2MB).
+You can go to [Board] tab of Smart Configurator editor to check the correctness of the device.
+In case the device is R5F572ND, at Board tab, you can click [...] button behind the Board combo-box
+to quickly go to Change Device dialog and change target device to R5F572NN.
+
+This issue will be fixed at newer version of board.
+
+---------------
+2. Usage Notes
+---------------
+This demonstration requires some information for the connection to IoTHub
+Please define HOST_NAME, DEVICE_ID, DEVICE_SYMMETRIC_KEY in src\sample_config.h

--- a/configuration/samples/iot_sdk_pnp/rsk-rx671/src/main.c
+++ b/configuration/samples/iot_sdk_pnp/rsk-rx671/src/main.c
@@ -68,7 +68,8 @@ extern VOID sample_entry(NX_IP* ip_ptr, NX_PACKET_POOL* pool_ptr, NX_DNS* dns_pt
 
 #ifndef SAMPLE_TIME_SERVER_NAME
 //#define SAMPLE_TIME_SERVER_NAME     "utcnist.colorado.edu"    /* Time Server.  */
-#define SAMPLE_TIME_SERVER_NAME       "time4.nrc.ca"
+//#define SAMPLE_TIME_SERVER_NAME     "time4.nrc.ca"
+#define SAMPLE_TIME_SERVER_NAME       "0.pool.ntp.org"
 #endif /* SAMPLE_TIME_SERVER_NAME */
 
 /* Default time. GMT: Saturday, January 1, 2022 12:00:00 AM. Epoch timestamp: 1640995200.  */

--- a/configuration/samples/iot_sdk_pnp/rx65n-cloudkit/src/main.c
+++ b/configuration/samples/iot_sdk_pnp/rx65n-cloudkit/src/main.c
@@ -68,7 +68,8 @@ extern VOID sample_entry(NX_IP* ip_ptr, NX_PACKET_POOL* pool_ptr, NX_DNS* dns_pt
 
 #ifndef SAMPLE_TIME_SERVER_NAME
 //#define SAMPLE_TIME_SERVER_NAME     "utcnist.colorado.edu"    /* Time Server.  */
-#define SAMPLE_TIME_SERVER_NAME       "time4.nrc.ca"
+//#define SAMPLE_TIME_SERVER_NAME     "time4.nrc.ca"
+#define SAMPLE_TIME_SERVER_NAME       "0.pool.ntp.org"
 #endif /* SAMPLE_TIME_SERVER_NAME */
 
 /* Default time. GMT: Saturday, January 1, 2022 12:00:00 AM. Epoch timestamp: 1640995200.  */

--- a/configuration/samples/ramdisk/rx72n/README.md
+++ b/configuration/samples/ramdisk/rx72n/README.md
@@ -1,7 +1,17 @@
 ------------------------
 1. Caution / Known Issue
 ------------------------
-The "_end" section in src/linker_script.ld should be at the end.
+1.1. The device on RX72N Envision Kit is R5F572NN (Flash memory 4MB).
+However, when creating new project with old board version (v1.11 and older),
+the project is created with R5F572ND device (Flash memory 2MB).
+You can go to [Board] tab of Smart Configurator editor to check the correctness of the device.
+In case the device is R5F572ND, at Board tab, you can click [...] button behind the Board combo-box
+to quickly go to Change Device dialog and change target device to R5F572NN.
+
+This issue will be fixed at newer version of board.
+
+
+1.2. The "_end" section in src/linker_script.ld should be at the end.
 
 However, the section order in linker_script.ld is changed when first build and after code generated.
 

--- a/configuration/samples/temperature_pnp/rsk-rx671/src/main.c
+++ b/configuration/samples/temperature_pnp/rsk-rx671/src/main.c
@@ -68,7 +68,8 @@ extern VOID sample_entry(NX_IP* ip_ptr, NX_PACKET_POOL* pool_ptr, NX_DNS* dns_pt
 
 #ifndef SAMPLE_TIME_SERVER_NAME
 //#define SAMPLE_TIME_SERVER_NAME     "utcnist.colorado.edu"    /* Time Server.  */
-#define SAMPLE_TIME_SERVER_NAME       "time4.nrc.ca"
+//#define SAMPLE_TIME_SERVER_NAME     "time4.nrc.ca"
+#define SAMPLE_TIME_SERVER_NAME       "0.pool.ntp.org"
 #endif /* SAMPLE_TIME_SERVER_NAME */
 
 /* Default time. GMT: Saturday, January 1, 2022 12:00:00 AM. Epoch timestamp: 1640995200.  */

--- a/configuration/samples/temperature_pnp/rx65n-cloudkit/src/main.c
+++ b/configuration/samples/temperature_pnp/rx65n-cloudkit/src/main.c
@@ -68,7 +68,8 @@ extern VOID sample_entry(NX_IP* ip_ptr, NX_PACKET_POOL* pool_ptr, NX_DNS* dns_pt
 
 #ifndef SAMPLE_TIME_SERVER_NAME
 //#define SAMPLE_TIME_SERVER_NAME     "utcnist.colorado.edu"    /* Time Server.  */
-#define SAMPLE_TIME_SERVER_NAME       "time4.nrc.ca"
+//#define SAMPLE_TIME_SERVER_NAME     "time4.nrc.ca"
+#define SAMPLE_TIME_SERVER_NAME       "0.pool.ntp.org"
 #endif /* SAMPLE_TIME_SERVER_NAME */
 
 /* Default time. GMT: Saturday, January 1, 2022 12:00:00 AM. Epoch timestamp: 1640995200.  */


### PR DESCRIPTION
Update readme for RX72N Envision Kit and unify default time server to 0.pool.ntp.org