### PR TITLE
Update for v6.1.12_rel-rx-1.0.0 RC3

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ This Azure RTOS repository that includes some modules (ThreadX/NetX/FileX/etc) a
   * Update Azure RTOS libraries to 6.1.12_rel
   * Improve sample linker script file
   * Set "-dbl_size=8" as default build option for CC-RX project
+  * Set "64 bits" for size of type 'double' as default build option for IAR project
   * Rename PnP Temperature Control sample project to IoT Embedded SDK with IoT Plug and Play sample project
 * 6.1.11_rel-rx-1.0.0
   * Update Azure RTOS libraries to 6.1.11_rel

--- a/configuration/azure-rtos.xml
+++ b/configuration/azure-rtos.xml
@@ -3190,5 +3190,39 @@
 			<remove>1</remove>
 			<data>                      &lt;state&gt;2&lt;/state&gt;</data>
 		</sourceedit>
+		<sourceedit>
+			<toolchain>ICCRX</toolchain>
+			<board>RSKRX65N-2MB</board>
+			<board>RSKRX65N-2MB(TSIP)</board>
+			<board>RX65NCloudKit</board>
+			<board>CloudKitRX65N</board>
+			<board>CK-RX65N</board>
+			<board>RX72NEnvisionKit</board>
+			<board>EnvisionKitRX72N</board>
+			<file>*.ewp</file>
+			<key>&lt;name&gt;Release&lt;/name&gt;</key>
+			<key>option</key>
+			<key>GenDataModel</key>
+			<remove>1</remove>
+			<data>                      &lt;state&gt;2&lt;/state&gt;</data>
+		</sourceedit>
+		<sourceedit>
+			<toolchain>ICCRX</toolchain>
+			<file>*.ewp</file>
+			<key>&lt;name&gt;Debug&lt;/name&gt;</key>
+			<key>option</key>
+			<key>GenDoubleSize</key>
+			<remove>1</remove>
+			<data>                      &lt;state&gt;1&lt;/state&gt;</data>
+		</sourceedit>
+		<sourceedit>
+			<toolchain>ICCRX</toolchain>
+			<file>*.ewp</file>
+			<key>&lt;name&gt;Release&lt;/name&gt;</key>
+			<key>option</key>
+			<key>GenDoubleSize</key>
+			<remove>1</remove>
+			<data>                      &lt;state&gt;1&lt;/state&gt;</data>
+		</sourceedit>
 	</package>
 </refinfo>

--- a/configuration/samples/bare/README.md
+++ b/configuration/samples/bare/README.md
@@ -4,9 +4,11 @@
 1.1. For more information about how to use this sample project, 
 please refer to section 2.1 of r01an6455ej0100-rx-azure-rtos.pdf
 
-1.2. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+1.2. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 1.3. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.

--- a/configuration/samples/guix_16bpp/README.md
+++ b/configuration/samples/guix_16bpp/README.md
@@ -17,12 +17,14 @@ https://docs.microsoft.com/azure/rtos/guix/about-guix
 1.2. For more information about how to use this sample project, 
 please refer to section 2.8 of r01an6455ej0100-rx-azure-rtos.pdf
 
-1.3. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+1.3. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 1.4. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.
 
 
 ------------------------

--- a/configuration/samples/guix_16bpp/rx72n-envision-kit/README.md
+++ b/configuration/samples/guix_16bpp/rx72n-envision-kit/README.md
@@ -17,12 +17,14 @@ https://docs.microsoft.com/azure/rtos/guix/about-guix
 1.2. For more information about how to use this sample project, 
 please refer to section 2.8 of r01an6455ej0100-rx-azure-rtos.pdf
 
-1.3. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+1.3. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 1.4. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.
 
 
 ------------------------

--- a/configuration/samples/guix_8bpp/README.md
+++ b/configuration/samples/guix_8bpp/README.md
@@ -17,9 +17,11 @@ https://docs.microsoft.com/azure/rtos/guix/about-guix
 1.2. For more information about how to use this sample project, 
 please refer to section 2.8 of r01an6455ej0100-rx-azure-rtos.pdf
 
-1.3. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+1.3. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 1.4. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.

--- a/configuration/samples/iot_sdk/README.md
+++ b/configuration/samples/iot_sdk/README.md
@@ -4,9 +4,11 @@
 1.1. For more information about how to use this sample project, 
 please refer to section 2.5 of r01an6455ej0100-rx-azure-rtos.pdf
 
-1.2. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+1.2. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 1.3. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.

--- a/configuration/samples/iot_sdk/rsk-rx671/README.md
+++ b/configuration/samples/iot_sdk/rsk-rx671/README.md
@@ -14,12 +14,14 @@ To use PMOD2, following modifications are required
 1.2. For more information about how to use this sample project, 
 please refer to section 2.5 of r01an6455ej0100-rx-azure-rtos.pdf
 
-1.3. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+1.3. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 1.4. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.
 
 1.5. If you are using e2 studio 2022-04/Smart Configurator 2.13.0 or earlier, 
 please do the following change on pin setting for SCI0 and SCI2.

--- a/configuration/samples/iot_sdk/rx72n-envision-kit/README.md
+++ b/configuration/samples/iot_sdk/rx72n-envision-kit/README.md
@@ -16,9 +16,11 @@ This issue is fixed from board version v1.12.
 2.1. For more information about how to use this sample project, 
 please refer to section 2.5 of r01an6455ej0100-rx-azure-rtos.pdf
 
-2.2. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+2.2. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 2.3. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.

--- a/configuration/samples/iot_sdk_pnp/README.md
+++ b/configuration/samples/iot_sdk_pnp/README.md
@@ -4,9 +4,11 @@
 1.1. For more information about how to use this sample project, 
 please refer to section 2.6 of r01an6455ej0100-rx-azure-rtos.pdf
 
-1.2. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+1.2. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 1.3. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.

--- a/configuration/samples/iot_sdk_pnp/rsk-rx671/README.md
+++ b/configuration/samples/iot_sdk_pnp/rsk-rx671/README.md
@@ -14,12 +14,14 @@ To use PMOD2, following modifications are required
 1.2. For more information about how to use this sample project, 
 please refer to section 2.6 of r01an6455ej0100-rx-azure-rtos.pdf
 
-1.3. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+1.3. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 1.4. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.
 
 1.5. If you are using e2 studio 2022-04/Smart Configurator 2.13.0 or earlier, 
 please do the following change on pin setting for SCI0 and SCI2.

--- a/configuration/samples/iot_sdk_pnp/rx72n-envision-kit/README.md
+++ b/configuration/samples/iot_sdk_pnp/rx72n-envision-kit/README.md
@@ -16,9 +16,11 @@ This issue is fixed from board version v1.12.
 2.1. For more information about how to use this sample project, 
 please refer to section 2.6 of r01an6455ej0100-rx-azure-rtos.pdf
 
-2.2. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+2.2. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 2.3. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.

--- a/configuration/samples/iperf/README.md
+++ b/configuration/samples/iperf/README.md
@@ -4,9 +4,11 @@
 1.1. For more information about how to use this sample project, 
 please refer to section 2.4 of r01an6455ej0100-rx-azure-rtos.pdf
 
-1.2. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+1.2. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 1.3. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.

--- a/configuration/samples/low_power/README.md
+++ b/configuration/samples/low_power/README.md
@@ -4,9 +4,11 @@
 1.1. For more information about how to use this sample project, 
 please refer to section 2.10 of r01an6455ej0100-rx-azure-rtos.pdf
 
-1.2. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+1.2. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 1.3. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.

--- a/configuration/samples/ping/README.md
+++ b/configuration/samples/ping/README.md
@@ -4,9 +4,11 @@
 1.1. For more information about how to use this sample project, 
 please refer to section 2.3 of r01an6455ej0100-rx-azure-rtos.pdf
 
-1.2. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+1.2. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 1.3. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.

--- a/configuration/samples/ping/rsk-rx671/README.md
+++ b/configuration/samples/ping/rsk-rx671/README.md
@@ -14,9 +14,11 @@ To use PMOD2, following modifications are required
 1.2. For more information about how to use this sample project, 
 please refer to section 2.3 of r01an6455ej0100-rx-azure-rtos.pdf
 
-1.3. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+1.3. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 1.4. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.

--- a/configuration/samples/ramdisk/README.md
+++ b/configuration/samples/ramdisk/README.md
@@ -4,9 +4,11 @@
 1.1. For more information about how to use this sample project, 
 please refer to section 2.2 of r01an6455ej0100-rx-azure-rtos.pdf
 
-1.2. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+1.2. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 1.3. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.

--- a/configuration/samples/ramdisk/rx130/README.md
+++ b/configuration/samples/ramdisk/rx130/README.md
@@ -27,9 +27,11 @@ If you are using other RX130 devices, please open linker_script.ld and move the 
 2.1. For more information about how to use this sample project, 
 please refer to section 2.2 of r01an6455ej0100-rx-azure-rtos.pdf
 
-2.2. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+2.2. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 2.3. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.

--- a/configuration/samples/ramdisk/rx140/README.md
+++ b/configuration/samples/ramdisk/rx140/README.md
@@ -27,9 +27,11 @@ If you are using other RX140 devices, please open linker_script.ld and move the 
 2.1. For more information about how to use this sample project, 
 please refer to section 2.2 of r01an6455ej0100-rx-azure-rtos.pdf
 
-2.2. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+2.2. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 2.3. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.

--- a/configuration/samples/ramdisk/rx72n/README.md
+++ b/configuration/samples/ramdisk/rx72n/README.md
@@ -37,8 +37,10 @@ If you are using other RX72N devices, please open linker_script.ld and move the 
 2.1. For more information about how to use this sample project, 
 please refer to section 2.2 of r01an6455ej0100-rx-azure-rtos.pdf
 
-2.2. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+2.2. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 2.3. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.

--- a/configuration/samples/temperature_pnp/README.md
+++ b/configuration/samples/temperature_pnp/README.md
@@ -4,9 +4,11 @@
 1.1. For more information about how to use this sample project, 
 please refer to section 2.7 of r01an6455ej0100-rx-azure-rtos.pdf
 
-1.2. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+1.2. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 1.3. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.

--- a/configuration/samples/temperature_pnp/rsk-rx671/README.md
+++ b/configuration/samples/temperature_pnp/rsk-rx671/README.md
@@ -14,12 +14,14 @@ To use PMOD2, following modifications are required
 1.2. For more information about how to use this sample project, 
 please refer to section 2.7 of r01an6455ej0100-rx-azure-rtos.pdf
 
-1.3. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+1.3. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 1.4. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.
 
 1.5. If you are using e2 studio 2022-04/Smart Configurator 2.13.0 or earlier, 
 please do the following change on pin setting for SCI0 and SCI2.

--- a/configuration/samples/temperature_pnp/rx72n-envision-kit/README.md
+++ b/configuration/samples/temperature_pnp/rx72n-envision-kit/README.md
@@ -16,9 +16,11 @@ This issue is fixed from board version v1.12.
 2.1. For more information about how to use this sample project, 
 please refer to section 2.7 of r01an6455ej0100-rx-azure-rtos.pdf
 
-2.2. From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+2.2. From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 2.3. Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.

--- a/configuration/samples/usbx_device_cdc_acm/README.md
+++ b/configuration/samples/usbx_device_cdc_acm/README.md
@@ -5,12 +5,14 @@ This demonstration illustrates the setup and use of USBX device CDC-ACM Class to
 For more information about how to use this sample project, 
 please refer to section 2.9 of r01an6455ej0100-rx-azure-rtos.pdf
 
-From software package v6.1.12_rel-rx.1.0.0, "-dbl_size=8" compiler build option is set as default for CC-RX project 
-to keep 8 bytes size for double type.
+From software package v6.1.12_rel-rx.1.0.0, to keep 8 bytes size for double type
+ "-dbl_size=8" compiler build option is set as default for CC-RX project
+ Size of type 'double' is set to "64 bits" as default for IAR project
+ Please set "-m64bit-doubles" manually for GCC project
 
 Please also take note that the sample project is verified with C project.
 If you create new project with C++ option, please confirm its behaviour by yourself.
-For example, if you create project with C++ option and CCRX compiler, you will need to add abort() function manually.
+For example, if you create project with C++ option and CC-RX compiler, you will need to add abort() function manually.
 
 
 Changes of sample project


### PR DESCRIPTION
Set "64 bits" for size of type 'double' as default for IAR project